### PR TITLE
Load Lit from local bundle

### DIFF
--- a/clock_pv_forecast_card.js
+++ b/clock_pv_forecast_card.js
@@ -1,5 +1,5 @@
 // pv-forecast-card
-import { LitElement, html, css } from 'https://unpkg.com/lit@2.8.0/index.js?module';
+import { LitElement, html, css } from 'lit';
 
 console.info("📦 clock-pv-forecast-card v0.025 loaded");
 


### PR DESCRIPTION
## Summary
- Load Lit from Home Assistant's bundled package instead of an external CDN

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aa330b842c8331b35a502139c9b580