### PR TITLE
feat: add remaining energy marker option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ Heavily inspired by [Clock Weather Card](https://github.com/pkissling/clock-weat
 - 7-day PV forecast using your preferred integration - you can choose which days to display! (Today and tomorrow remain mandatory)
 - Animated bars with customizable colors
 - Responsive and localized layout
-- Optional remaining energy bar (with shrinking animation and alert color)
+- Optional remaining energy indicator (bar or marker) with shrinking animation and alert color in bar mode
 - **NEW**: Three display modes for day labels:
   - **Weekday mode**: Traditional weekday names (Mon, Tue, etc.)
   - **Date mode**: Short date format (12.6., Jun 12, etc.) - respects your system locale
   - **Relative mode**: Relative day indicators (Today, Tomorrow, +2d, +3d, etc.; optional +1d for tomorrow)
-- Customizable remaining bar label - change "Remaining" to your preferred text
+- Customizable remaining indicator label - change "Remaining" to your preferred text
 - Fully internationalized error messages using Home Assistant's localization system
 - Tooltips with detailed information and last update time
 
@@ -151,6 +151,7 @@ entity_day3: sensor.solcast_pv_forecast_prognose_tag_3
 type: custom:clock-pv-forecast-card
 display_mode: date
 date_format: numeric
+remaining_indicator: marker
 entity_remaining: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
 entity_today: sensor.solcast_pv_forecast_prognose_heute
 entity_tomorrow: sensor.solcast_pv_forecast_prognose_morgen
@@ -184,7 +185,8 @@ show_tooltips: true
 | `display_mode`                  | `string` | **NEW**: Display mode: `weekday`, `date`, or `relative` (default: `weekday`) |
 | `weekday_format`                | `string` | For weekday mode: `narrow`, `short`, or `long` (default: `short`) |
 | `date_format`                   | `string` | For date mode: `short` (12. Jun) or `numeric` (12.6.) (default: `short`) |
-| `remaining_label`               | `string` | Custom label for remaining bar (default: "Rest") |
+| `remaining_label`               | `string` | Custom label for remaining indicator (default: "Rest") |
+| `remaining_indicator`           | `string` | Display style for remaining value: `bar` (default) or `marker` |
 | `animation_duration`            | `string` | CSS time (e.g. `0.5s`, `2s`)                           |
 | `bar_color_start` / `end`       | `string` | Gradient colors for main bars                          |
 | `remaining_color_start` / `end` | `string` | Gradient colors for remaining bar                      |
@@ -235,7 +237,7 @@ The card now uses Home Assistant's built-in localization system for all error me
 - Use `vertical-stack` or `grid` layouts for better integration
 - Colors can use `var(--theme-color)` from your HA theme
 - Try [Google's color picker](https://www.google.com/search?q=hex+color+picker)
-- Customize the remaining bar label with `remaining_label` to match your use case (e.g., "Battery", "Available", "Remaining")
+- Customize the remaining indicator label with `remaining_label` to match your use case (e.g., "Battery", "Available", "Remaining")
 - Enable tooltips with `show_tooltips: true` for detailed information when hovering over bars
 - Column width automatically adjusts based on your chosen display mode
 - Date mode is perfect for weekly planning, relative mode for quick at-a-glance information (use `relative_plus_one` for "+1d" tomorrow)
@@ -249,12 +251,12 @@ The card now uses Home Assistant's built-in localization system for all error me
 - 7-Tage PV-Prognose mit wählbaren Tagen
 - Animierte Balken mit anpassbaren Farben
 - Responsive und lokalisierte Darstellung
-- Optionaler Verbrauchsbalken mit Warnfunktion
+- Optionaler Verbrauchsindikator (Balken oder Marker) mit Warnfunktion (Balkenmodus)
 - **NEU**: Drei Anzeigemodi für Tageslabels:
   - **Wochentag-Modus**: Traditionelle Wochentagsnamen (Mo, Di, etc.)
   - **Datums-Modus**: Kurzes Datumsformat (12.6., 12. Jun, etc.) - respektiert die Systemsprache
   - **Relativer Modus**: Relative Tagesangaben (Heute, Morgen, +2d, +3d, etc.; optional +1d für Morgen)
-- Anpassbares Label für Verbrauchsbalken
+- Anpassbares Label für Verbrauchsindikator
 - Vollständig internationalisierte Fehlermeldungen
 - Tooltips mit detaillierten Informationen
 
@@ -301,6 +303,7 @@ entity_day3: sensor.solcast_pv_forecast_prognose_tag_3
 type: custom:clock-pv-forecast-card
 display_mode: date
 date_format: numeric
+remaining_indicator: marker
 entity_remaining: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
 entity_today: sensor.solcast_pv_forecast_prognose_heute
 entity_tomorrow: sensor.solcast_pv_forecast_prognose_morgen
@@ -334,7 +337,8 @@ show_tooltips: true
 | `display_mode`                  | `string` | **NEU**: Anzeigemodus: `weekday`, `date`, oder `relative` (Standard: `weekday`) |
 | `weekday_format`                | `string` | Für Wochentag-Modus: `narrow`, `short`, oder `long` (Standard: `short`) |
 | `date_format`                   | `string` | Für Datums-Modus: `short` (12. Jun) oder `numeric` (12.6.) (Standard: `short`) |
-| `remaining_label`               | `string` | Angepasstes Label für Verbrauchsbalken (Standard: "Rest") |
+| `remaining_label`               | `string` | Angepasstes Label für Verbrauchsindikator (Standard: "Rest") |
+| `remaining_indicator`           | `string` | Anzeige des verbleibenden Werts: `bar` (Standard) oder `marker` |
 | `animation_duration`            | `string` | CSS-Zeit (z.B. `0.5s`, `2s`)                          |
 | `bar_color_start` / `end`       | `string` | Verlaufsfarben für Hauptbalken                        |
 | `remaining_color_start` / `end` | `string` | Verlaufsfarben für Verbrauchsbalken                   |
@@ -371,7 +375,7 @@ show_tooltips: true
 - Nutze `vertical-stack` oder `grid` Layouts für bessere Integration
 - Farben können `var(--theme-color)` aus deinem HA-Theme verwenden
 - Probiere [Google's Farbwähler](https://www.google.com/search?q=hex+color+picker) aus
-- Passe das Verbrauchsbalken-Label mit `remaining_label` an deinen Anwendungsfall an (z.B. "Batterie", "Verfügbar", "Rest")
+- Passe das Verbrauchsindikator-Label mit `remaining_label` an deinen Anwendungsfall an (z.B. "Batterie", "Verfügbar", "Rest")
 - Aktiviere Tooltips mit `show_tooltips: true` für detaillierte Informationen beim Hover über Balken
 - Die Spaltenbreite passt sich automatisch an den gewählten Anzeigemodus an
 - Datums-Modus ist perfekt für Wochenplanung, relativer Modus für schnelle Übersichtsinformationen (nutze `relative_plus_one` für "+1d" morgen)

--- a/clock_pv_forecast_card.js
+++ b/clock_pv_forecast_card.js
@@ -64,6 +64,7 @@ class ClockPvForecastCard extends LitElement {
       day_column_width: dayColumnWidth,
       entity_remaining: config.entity_remaining || null,
       remaining_label: config.remaining_label || 'Rest',
+      remaining_indicator: config.remaining_indicator || 'bar',
       show_tooltips: config.show_tooltips ?? false,
       ...config,
     };
@@ -116,7 +117,7 @@ class ClockPvForecastCard extends LitElement {
     return html`
       <ha-card>
         <div class="forecast-rows" role="table" aria-label="PV Forecast">
-          ${this.config.entity_remaining ? this._renderRemainingBar() : ''}
+          ${this.config.entity_remaining && this.config.remaining_indicator === 'bar' ? this._renderRemainingBar() : ''}
           ${forecast.map((item, index) => this._renderForecastRow(item, index))}
         </div>
       </ha-card>
@@ -137,12 +138,21 @@ class ClockPvForecastCard extends LitElement {
 
     const dayLabel = this._getDayLabel(item.offset);
     const barStyle = `--bar-width: ${this._barWidth(value)}%; --bar-gradient: linear-gradient(to right, ${this.config.bar_color_start}, ${this.config.bar_color_end}); --animation-time: ${this.config.animation_duration}`;
-    
+
+    let remainingDot = '';
+    if (item.offset === 0 && this.config.remaining_indicator === 'marker' && this.config.entity_remaining) {
+      const remaining = parseFloat(this.hass.states[this.config.entity_remaining]?.state || '0');
+      const produced = value - remaining;
+      const percent = Math.max(0, Math.min(100, (produced / this.config.max_value) * 100));
+      remainingDot = html`<div class="remaining-dot" style="left: ${percent}%"></div>`;
+    }
+
     return html`
       <div class="forecast-row" role="row" aria-label="Tag ${index + 1}">
         <div class="day" role="cell" style="width: ${this.config.day_column_width}">${dayLabel}</div>
         <div class="bar-container" role="cell" aria-label="Prognose ${this._formatValue(value, item.entity)}">
           <div class="bar" style="${barStyle}" aria-hidden="true"></div>
+          ${remainingDot}
           ${this.config.show_tooltips ? this._renderTooltip(value, item.entity, dayLabel) : ''}
         </div>
         <div class="value" role="cell">${this._formatValue(value, item.entity)}</div>
@@ -365,7 +375,17 @@ class ClockPvForecastCard extends LitElement {
     .bar.blink {
       animation: fill-bar var(--animation-time) ease-out forwards, blink 1s infinite;
     }
-    
+
+    .remaining-dot {
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--primary-color);
+    }
+
     .value {
       width: 4.5em;
       text-align: right;


### PR DESCRIPTION
## Summary
- add configurable remaining energy indicator (bar or marker)
- draw marker for produced energy on today's forecast when using marker mode
- style marker indicator
- document remaining indicator configuration in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aa2f3d5008833193d761419215bdb1